### PR TITLE
bug: Support composite conditions with duplicate key names

### DIFF
--- a/neverpile-commons-authorization/src/test/resources/com/neverpile/authorization/config/non-simple-composite-condition.json
+++ b/neverpile-commons-authorization/src/test/resources/com/neverpile/authorization/config/non-simple-composite-condition.json
@@ -1,0 +1,23 @@
+{
+  "validFrom" : "1970-01-01T00:00:00.000Z",
+  "description": "some policy",
+  "default_effect": "DENY",
+  "rules": [
+    {
+      "name": "Test deserialization of or-condition",
+      "effect": "ALLOW",
+      "subjects": ["*"],
+      "resources": ["*"],
+      "actions": ["*"],
+      "conditions": {
+        "or": {
+          "conditions": [
+            { "equals": {	"foo1": true	} },
+            { "equals": {	"foo2": true	} },
+            { "equals": {	"foo3": true	} }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/neverpile-commons-condition/src/main/java/com/neverpile/common/condition/config/ConditionModule.java
+++ b/neverpile-commons-condition/src/main/java/com/neverpile/common/condition/config/ConditionModule.java
@@ -1,6 +1,6 @@
 package com.neverpile.common.condition.config;
 
-import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.*;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -17,12 +17,15 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.SerializationConfig;
@@ -37,6 +40,7 @@ import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import com.neverpile.common.condition.CompositeCondition;
 import com.neverpile.common.condition.Condition;
 import com.neverpile.common.condition.CoreConditionRegistry;
+import com.neverpile.common.specifier.Specifier;
 
 /**
  * A Jackson {@link Module} extending Jackson with capabilities for the marshalling and
@@ -63,6 +67,12 @@ public class ConditionModule extends SimpleModule {
 
     setSerializerModifier(new ConditionSerializerModifier());
     setDeserializerModifier(new ConditionDeserializerModifier());
+    addKeySerializer(Specifier.class, new JsonSerializer<Specifier>() {
+      @Override
+      public void serialize(Specifier value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeFieldName(value.asString());
+      }
+    });
   }
 
   @PostConstruct
@@ -89,14 +99,36 @@ public class ConditionModule extends SimpleModule {
         super.serializeFields(bean, gen, provider);
 
         CompositeCondition<?> dto = (CompositeCondition<?>) bean;
-        for (Condition c : dto.getConditions()) {
-          String name = conditionNameByClass.get(c.getClass());
-
-          if (null == name)
-            throw new IllegalArgumentException(
-                "Cannot serialize condition of type " + c.getClass() + ": name cannot be resolved");
-
-          provider.defaultSerializeField(name, c, gen);
+        
+        // determine whether we can serialize in simple form by looking at whether there would be duplicate keys
+        boolean canSerializeSimple = dto.getConditions().stream().map(c -> conditionNameByClass.get(c.getClass())).distinct().count()  // 
+            == dto.getConditions().size();
+        
+        if(canSerializeSimple) {
+          for (Condition c : dto.getConditions()) {
+            String name = conditionNameByClass.get(c.getClass());
+  
+            if (null == name)
+              throw new IllegalArgumentException(
+                  "Cannot serialize condition of type " + c.getClass() + ": name cannot be resolved");
+  
+            provider.defaultSerializeField(name, c, gen);
+          }
+        } else {
+          gen.writeFieldName("conditions");
+          gen.writeStartArray();
+          for (Condition c : dto.getConditions()) {
+            String name = conditionNameByClass.get(c.getClass());
+  
+            if (null == name)
+              throw new IllegalArgumentException(
+                  "Cannot serialize condition of type " + c.getClass() + ": name cannot be resolved");
+  
+            gen.writeStartObject();
+            provider.defaultSerializeField(name, c, gen);
+            gen.writeEndObject();
+          }
+          gen.writeEndArray();
         }
       }
     }
@@ -112,20 +144,20 @@ public class ConditionModule extends SimpleModule {
   }
 
   public class ConditionDeserializerModifier extends BeanDeserializerModifier {
+    
     public class CompositeConditionDeserializer extends BeanDeserializer {
       private static final long serialVersionUID = 1L;
 
       public CompositeConditionDeserializer(final BeanDeserializerBase base) {
         super(base);
-
+        
       }
 
-      @Override
-      protected void handleUnknownProperty(final JsonParser p, final DeserializationContext ctxt,
-          final Object beanOrClass, final String propName) throws IOException {
-        Class<? extends Condition> conditionClass = conditionClassByName.get(propName);
+      private void deserializeNamedCondition(final JsonParser p, final DeserializationContext ctxt, final Object beanOrClass, final String conditionName)
+          throws UnrecognizedPropertyException, JsonMappingException, IOException, JsonProcessingException {
+        Class<? extends Condition> conditionClass = conditionClassByName.get(conditionName);
         if (null == conditionClass)
-          throw UnrecognizedPropertyException.from(p, beanOrClass, propName,
+          throw UnrecognizedPropertyException.from(p, beanOrClass, conditionName,
               new ArrayList<>(conditionClassByName.keySet()));
         else {
           JavaType valueType = ctxt.getTypeFactory().constructType(conditionClass);
@@ -133,6 +165,103 @@ public class ConditionModule extends SimpleModule {
           Object value = deserializer.deserialize(p, ctxt);
           ((CompositeCondition<?>) beanOrClass).addCondition((Condition) value);
         }
+      }
+      
+      @Override
+      protected void handleUnknownProperty(final JsonParser p, final DeserializationContext ctxt,
+          final Object beanOrClass, final String propName) throws IOException {
+        deserializeNamedCondition(p, ctxt, beanOrClass, propName);
+      }
+
+      @Override
+      protected void handleIgnoredProperty(JsonParser p, DeserializationContext ctxt, Object beanOrClass, String propName) throws IOException {
+        /*
+         * Support conditions in an array namend "conditions" for cases when the condition names are not unique.
+         * 
+         * The JSON must look like this:
+         * "or": {
+         *   "conditions": [  // We are here!
+         *     { "equals": { "foo1": true  } },
+         *     { "equals": { "foo2": true  } },
+         *     { "equals": { "foo3": true  } }
+         *   ]
+         * }
+         * 
+         * These are also acceptable:
+         * "or": {
+         *   "conditions": null, // ignored
+         *   "conditions": [], // ignored
+         *   "equals": { "foo1": true  } // other conditions in simple form
+         * }
+         * 
+         * "or": {
+         *   "conditions": [
+         *     { 
+         *       "equals": { "foo1": true  }, // nested conditions with different name in one object entry  
+         *       "exists": { "target": "something" }  
+         *     }
+         *   ]
+         * }
+         */
+        if ("conditions".equals(propName)) {
+          JsonToken tok = p.currentToken();
+          switch (tok) {
+          case VALUE_NULL:
+            // ignore null value
+            return;
+
+          case START_ARRAY:
+            do {
+              tok = p.nextToken();
+              switch (tok) {
+              case END_ARRAY:
+                break; // end loop
+                
+              case START_OBJECT:
+                // each object must contain one or more conditions keyed by type
+                do {
+                  tok = p.nextToken();
+                  switch (tok) {
+                  case END_OBJECT:
+                    break; // end loop
+                    
+                  case FIELD_NAME:
+                    String conditionName = p.getCurrentName();
+                    
+                    // The deserializer for a named condition expects to be located
+                    // at the start object token.
+                    if(p.nextToken() != JsonToken.START_OBJECT) {
+                      ctxt.handleUnexpectedToken(beanOrClass.getClass(), p);
+                      break;
+                    }
+                    
+                    deserializeNamedCondition(p, ctxt, beanOrClass, conditionName);
+                    break;
+                    
+                  default:
+                    ctxt.handleUnexpectedToken(beanOrClass.getClass(), p);
+                    break;
+                  }
+                } while (tok != JsonToken.END_OBJECT);
+                break;
+                
+              default:
+                ctxt.handleUnexpectedToken(beanOrClass.getClass(), p);
+                break;
+              }
+            } while (tok != JsonToken.END_ARRAY);
+            break;
+            
+          default:
+            ctxt.handleUnexpectedToken(beanOrClass.getClass(), p);
+            break;
+          }
+          
+          return;
+        }
+        
+        // fail on all unknown properties
+        throw UnrecognizedPropertyException.from(p, beanOrClass, propName, getKnownPropertyNames());
       }
     }
 

--- a/neverpile-commons-condition/src/test/java/com/neverpile/common/condition/json/ConditionJsonMarshallingTest.java
+++ b/neverpile-commons-condition/src/test/java/com/neverpile/common/condition/json/ConditionJsonMarshallingTest.java
@@ -1,0 +1,112 @@
+package com.neverpile.common.condition.json;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.neverpile.common.condition.AndCondition;
+import com.neverpile.common.condition.EqualsCondition;
+import com.neverpile.common.condition.ExistsCondition;
+import com.neverpile.common.condition.OrCondition;
+import com.neverpile.common.specifier.Specifier;
+
+@RunWith(SpringRunner.class)
+@JsonTest
+public class ConditionJsonMarshallingTest {
+  @Autowired
+  ObjectMapper mapper;
+
+  @Test
+  public void testThat_unmarshallingSupportsNonSimpleForm() throws Exception {
+    String json = "{" + //
+        "  \"or\": {" + //
+        "    \"conditions\": [" + //
+        "      { \"equals\": { \"foo1\": true  } }," + //
+        "      { \"equals\": { \"foo2\": true  } }" + //
+        "    ]" + //
+        "  }" + //
+        "}";
+
+    AndCondition and = (AndCondition) mapper.readValue(json, AndCondition.class);
+
+    // and must contain a single or
+    assertThat(and.getConditions()).hasSize(1);
+    assertThat(and.getConditions().get(0)).isInstanceOf(OrCondition.class);
+
+    // or must contain three equals
+    OrCondition or = (OrCondition) and.getConditions().get(0);
+    assertThat(or.getConditions()).hasSize(2);
+    assertThat(or.getConditions()).allMatch(c -> c instanceof EqualsCondition);
+    
+    assertThat(((EqualsCondition)or.getConditions().get(0)).getPredicates()).containsEntry(Specifier.from("foo1"), Collections.singletonList("true"));
+    assertThat(((EqualsCondition)or.getConditions().get(1)).getPredicates()).containsEntry(Specifier.from("foo2"), Collections.singletonList("true"));
+  }
+  
+  @Test
+  public void testThat_unmarshallingSupportsSimpleForm() throws Exception {
+    String json = "{" + //
+        "  \"or\": {" + //
+        "    \"equals\": { \"foo1\": true  }," + 
+        "    \"exists\": { \"target\": \"foo\" }" + 
+        "  }" + //
+        "}";
+    
+    AndCondition and = (AndCondition) mapper.readValue(json, AndCondition.class);
+    
+    // and must contain a single or
+    assertThat(and.getConditions()).hasSize(1);
+    assertThat(and.getConditions().get(0)).isInstanceOf(OrCondition.class);
+    
+    // or must contain three equals
+    OrCondition or = (OrCondition) and.getConditions().get(0);
+    assertThat(or.getConditions()).hasSize(2);
+
+    assertThat(or.getConditions().get(0)).isInstanceOf(EqualsCondition.class);
+    assertThat(((EqualsCondition)or.getConditions().get(0)).getPredicates()).containsEntry(Specifier.from("foo1"), Collections.singletonList("true"));
+    
+    assertThat(or.getConditions().get(1)).isInstanceOf(ExistsCondition.class);
+    assertThat(((ExistsCondition)or.getConditions().get(1)).getTargets()).containsExactly("foo");
+  }
+  
+  @Test
+  public void testThat_marshallingSupportsSimpleForm() throws Exception {
+    String json = "{" + //
+        "  \"or\": {" + //
+        "    \"equals\": { \"foo1\": [\"true\"]  }," + 
+        "    \"exists\": { \"targets\": [\"foo\"] }" + 
+        "  }" + //
+        "}";
+    
+    AndCondition and = (AndCondition) mapper.readValue(json, AndCondition.class);
+    
+    String serialized = mapper.writeValueAsString(and);
+    
+    assertThat(serialized).isEqualToIgnoringWhitespace(json);
+  }
+  
+  @Test
+  public void testThat_marshallingSupportsNonSimpleForm() throws Exception {
+    String json = "{" + //
+        "  \"or\": {" + //
+        "    \"conditions\": [" + //
+        "      { \"equals\": { \"foo1\": [\"true\"]  } }," + //
+        "      { \"equals\": { \"foo2\": [\"true\"]  } }" + //
+        "    ]" + //
+        "  }" + //
+        "}";
+
+    AndCondition and = (AndCondition) mapper.readValue(json, AndCondition.class);
+
+    String serialized = mapper.writeValueAsString(and);
+    
+    assertThat(serialized).isEqualToIgnoringWhitespace(json);
+  }
+
+}


### PR DESCRIPTION
Fix cases where composite conditions with multiple sub-conditions of the same type, e.g.
```
  "conditions": {
    "or": {
      "conditions": [
        { "equals": {	"foo": true } },
        { "equals": {	"bar": false } }
      ]
    }
  }
```
would not be correctly deserialized. 